### PR TITLE
fix: handle empty datasets in MiniLine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ npm-debug.log*
 yarn-*.log*
 pnpm-debug.log*
 .vercel
+*.tsbuildinfo

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -212,16 +212,25 @@ function MiniBar({ data }: { data: number[] }) {
 }
 function MiniLine({ data }: { data: number[] }) {
   const w = 220, h = 48, pad = 6, max = Math.max(1, ...data);
-  const points = data.map((v, i) => {
-    const x = pad + (i * (w - pad * 2)) / (data.length - 1 || 1);
-    const y = h - pad - (v / max) * (h - pad * 2);
-    return `${x},${y}`;
-  }).join(" ");
+  const denom = Math.max(data.length - 1, 1);
+  const points = data
+    .map((v, i) => {
+      const x = pad + (i * (w - pad * 2)) / denom;
+      const y = h - pad - (v / max) * (h - pad * 2);
+      return `${x},${y}`;
+    })
+    .join(" ");
   return (
     <svg width={w} height={h} className="mt-2">
-      <polyline points={points} fill="none" stroke="currentColor" className="text-green-600" strokeWidth="2" />
+      <polyline
+        points={points}
+        fill="none"
+        stroke="currentColor"
+        className="text-green-600"
+        strokeWidth="2"
+      />
       {data.map((v, i) => {
-        const x = pad + (i * (w - pad * 2)) / (data.length - 1 || 1);
+        const x = pad + (i * (w - pad * 2)) / denom;
         const y = h - pad - (v / max) * (h - pad * 2);
         return <circle key={i} cx={x} cy={y} r={2} className="fill-green-600" />;
       })}


### PR DESCRIPTION
## Summary
- prevent negative coordinate calculations when line chart receives empty data
- ignore TypeScript build info files

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6896ff36f6cc832db32eb20998c24a4e