### PR TITLE
ui: fix Quick Add spacing & disabled style

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1025,9 +1025,9 @@ function QuickAdd({
   };
 
   return (
-    <div className="flex items-center gap-3 bg-white border border-neutral-200 rounded-xl px-3 py-2 shadow-sm">
+    <div className="w-full md:w-[620px] md:ml-auto flex items-center gap-3 bg-white border border-neutral-200 rounded-xl px-3 py-2 shadow-sm">
       <input
-        className="flex-1 px-3 py-2 rounded-lg outline-none"
+        className="flex-1 h-11 text-sm px-3 rounded-lg outline-none placeholder:text-neutral-400"
         placeholder="Quick task…"
         aria-label="Task title"
         value={title}
@@ -1035,7 +1035,7 @@ function QuickAdd({
         onKeyDown={(e) => e.key === "Enter" && go()}
       />
       <select
-        className="px-3 py-2 rounded-lg border border-neutral-200 bg-white"
+        className="h-11 text-sm px-3 rounded-lg border border-neutral-200 bg-white"
         value={projectId}
         onChange={(e) => setProjectId(e.target.value)}
         aria-label="Project"
@@ -1051,7 +1051,7 @@ function QuickAdd({
       <button
         onClick={go}
         disabled={!title.trim()}
-        className="px-3 py-2 rounded-xl bg-black text-white disabled:opacity-50 hover:opacity-90 active:scale-[.99]"
+        className="h-11 text-sm px-4 rounded-lg bg-black text-white disabled:bg-neutral-200 disabled:text-neutral-500 disabled:cursor-not-allowed hover:opacity-90 active:scale-[.99]"
       >
         Add
       </button>


### PR DESCRIPTION
## Summary
- align Quick Add bar to the right on desktop and size components uniformly
- improve disabled button state and spacing for Quick Add form

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68970a1be118832da9f43cf16200fe37