### PR TITLE
Persist project and task data in localStorage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 
 "use client";
 import React, { useEffect, useMemo, useState, useCallback } from "react";
+import { loadProjects, loadTasks, saveProjects, saveTasks } from "../lib/storage";
 
 /* ===========================
    Flowgrid v1.5 — Canvas Build (No Persistence)
@@ -871,8 +872,14 @@ function Footer(){
 
 /* ---------- App page ---------- */
 export default function Page(){
-  const [projects,setProjects]=useState<Project[]>(seedProjects);
-  const [tasks,setTasks]=useState<Task[]>(seedTasks);
+  const [projects,setProjects]=useState<Project[]>(() => {
+    const stored = loadProjects();
+    return stored.length ? stored : seedProjects;
+  });
+  const [tasks,setTasks]=useState<Task[]>(() => {
+    const stored = loadTasks();
+    return stored.length ? stored : seedTasks;
+  });
 
   const [page,setPage]=useState<"dashboard"|"projects"|"tasks">("dashboard");
   const [activeProjectId,setActiveProjectId]=useState<string|null>(null);
@@ -891,6 +898,14 @@ export default function Page(){
     list.push("Heads-up: Carrier onboarding pack pending approvals");
     return list.slice(0,8);
   },[tasks]);
+
+  useEffect(() => {
+    saveProjects(projects);
+  }, [projects]);
+
+  useEffect(() => {
+    saveTasks(tasks);
+  }, [tasks]);
 
   useEffect(()=>{
     function onKey(e: KeyboardEvent){

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,40 @@
+const PROJECTS_KEY = "flowgrid_projects";
+const TASKS_KEY = "flowgrid_tasks";
+
+export function loadProjects(): any[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const data = localStorage.getItem(PROJECTS_KEY);
+    return data ? JSON.parse(data) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function loadTasks(): any[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const data = localStorage.getItem(TASKS_KEY);
+    return data ? JSON.parse(data) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveProjects(projects: any[]) {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(PROJECTS_KEY, JSON.stringify(projects));
+  } catch {
+    // ignore
+  }
+}
+
+export function saveTasks(tasks: any[]) {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(TASKS_KEY, JSON.stringify(tasks));
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
## Summary
- add storage helpers to read and write projects and tasks from localStorage
- load projects and tasks from storage on first render, falling back to seed data
- persist project and task updates back to storage via useEffect

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689710a68f58832db3208ed42e093ad2