### PR TITLE
chore: add vitest types to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,9 @@
       }
     ],
     "incremental": true,
+    "types": [
+      "vitest"
+    ],
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]


### PR DESCRIPTION
## Summary
- add Vitest types to tsconfig for type awareness
- restore tsconfig build info to keep repo clean

## Testing
- `npm test` *(fails: The symbol "quickAddTask" has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_689721a3f264832d916a8b776025efad